### PR TITLE
fix:VUCC_GRIDS check problem

### DIFF
--- a/dist/tcadif.js
+++ b/dist/tcadif.js
@@ -4029,6 +4029,7 @@ module.exports = {
     "IOTA_GROUP": "RSGB Islands on the Air (IOTA) Group",
     "RDA": "TAG Russian Districts Award (RDA) Mixed",
     "USACA": "CQ Magazine United States of America Counties (USA-CA) Mixed",
+    "VUCC": "ARRL VHF/UHF Century Club Program (VUCC)",
     "VUCC_BAND": "ARRL VHF/UHF Century Club Program (VUCC) Band",
     "VUCC_SATELLITE": "ARRL VHF/UHF Century Club Program (VUCC) Satellite",
     "WAB": "WAB AG Worked All Britain (WAB) Mixed",

--- a/dist/tcadif.js
+++ b/dist/tcadif.js
@@ -3202,7 +3202,7 @@ class VUCC_GRIDS extends FieldDef {
             fieldName: 'VUCC_GRIDS',
             dataType: 'GridSquareList',
             normalizer: (value) => value?.toUpperCase(),
-            check: value => (value.split(/,/g).length === 2 || value.split(/,/g).length === 4) && value.split(/,/g).every(grid => grid.length === 4),
+            check: value => (value.split(/,/g).length === 2 || value.split(/,/g).length === 4) && value.split(/,/g).every(grid => grid.length === 4 || grid.length === 6),
         });
     }
 }

--- a/lib/defs/VUCC_GRIDS.js
+++ b/lib/defs/VUCC_GRIDS.js
@@ -8,7 +8,7 @@ class VUCC_GRIDS extends FieldDef {
             fieldName: 'VUCC_GRIDS',
             dataType: 'GridSquareList',
             normalizer: (value) => value?.toUpperCase(),
-            check: value => (value.split(/,/g).length === 2 || value.split(/,/g).length === 4) && value.split(/,/g).every(grid => grid.length === 4),
+            check: value => (value.split(/,/g).length === 2 || value.split(/,/g).length === 4) && value.split(/,/g).every(grid => grid.length === 4 || grid.length === 6),
         });
     }
 }

--- a/lib/enums/Credit.js
+++ b/lib/enums/Credit.js
@@ -52,6 +52,7 @@ module.exports = {
     "IOTA_GROUP": "RSGB Islands on the Air (IOTA) Group",
     "RDA": "TAG Russian Districts Award (RDA) Mixed",
     "USACA": "CQ Magazine United States of America Counties (USA-CA) Mixed",
+    "VUCC": "ARRL VHF/UHF Century Club Program (VUCC)",
     "VUCC_BAND": "ARRL VHF/UHF Century Club Program (VUCC) Band",
     "VUCC_SATELLITE": "ARRL VHF/UHF Century Club Program (VUCC) Satellite",
     "WAB": "WAB AG Worked All Britain (WAB) Mixed",


### PR DESCRIPTION
The regular expression issue in 'VUCC_GRIDS' has been corrected, and it can now match GRIDS with a length of 6 characters.